### PR TITLE
Fixed typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The RED channel of the RGB Led must be connected to pin **2.7**. The GREEN chann
 #### Evaluation
 The evaluation of the assignment will take into consideration the following aspects of the project:
 - successful build process without any warning/error generated
-- successful programmin without any error generated
+- successful programming without any error generated
 - correct functioning of the device as per the requirements
 - code organization (header and source files, useful comments)
 - schematic organization and documentation


### PR DESCRIPTION
There was a little typo in word programming missing a "d"